### PR TITLE
JECC - Diagramme - Wenn vor Schnellwechsel eine Analysenänderung gesp…

### DIFF
--- a/JEVisControlCenter/src/main/java/org/jevis/jeconfig/dialog/SaveAnalysisDialog.java
+++ b/JEVisControlCenter/src/main/java/org/jevis/jeconfig/dialog/SaveAnalysisDialog.java
@@ -19,6 +19,7 @@ import org.jevis.jeconfig.JEConfig;
 import org.jevis.jeconfig.application.Chart.ChartPluginElements.PickerCombo;
 import org.jevis.jeconfig.application.Chart.ChartSettings;
 import org.jevis.jeconfig.application.Chart.data.AnalysisDataModel;
+import org.jevis.jeconfig.plugin.charts.ToolBarView;
 import org.jevis.jeconfig.tool.I18n;
 import org.joda.time.DateTime;
 
@@ -32,18 +33,20 @@ public class SaveAnalysisDialog {
     private final JEVisDataSource ds;
     private final AnalysisDataModel model;
     private final ObjectRelations objectRelations;
+    private final ToolBarView toolBarView;
     private PickerCombo pickerCombo;
     private ComboBox<JEVisObject> listAnalysesComboBox;
     private Boolean changed;
     private JEVisObject currentAnalysisDirectory = null;
 
-    public SaveAnalysisDialog(JEVisDataSource ds, AnalysisDataModel model, PickerCombo pickerCombo, ComboBox<JEVisObject> listAnalysesComboBox, Boolean changed) {
+    public SaveAnalysisDialog(JEVisDataSource ds, AnalysisDataModel model, ToolBarView toolBarView) {
         this.ds = ds;
         this.model = model;
+        this.toolBarView = toolBarView;
         this.objectRelations = new ObjectRelations(ds);
-        this.pickerCombo = pickerCombo;
-        this.listAnalysesComboBox = listAnalysesComboBox;
-        this.changed = changed;
+        this.pickerCombo = toolBarView.getPickerCombo();
+        this.listAnalysesComboBox = toolBarView.getListAnalysesComboBox();
+        this.changed = toolBarView.getChanged();
 
         saveCurrentAnalysis();
     }
@@ -142,7 +145,7 @@ public class SaveAnalysisDialog {
 
         newAnalysis.showAndWait()
                 .ifPresent(response -> {
-                    if (response.getButtonData().getTypeCode() == ButtonType.OK.getButtonData().getTypeCode()) {
+                    if (response.getButtonData().getTypeCode().equals(ButtonType.OK.getButtonData().getTypeCode())) {
                         List<String> check = new ArrayList<>();
                         AtomicReference<JEVisObject> currentAnalysis = new AtomicReference<>();
                         try {
@@ -170,11 +173,10 @@ public class SaveAnalysisDialog {
                             if (newAnalysisObject != null) {
                                 saveDataModel(newAnalysisObject, model.getSelectedData(), model.getCharts());
 
-                                model.setCurrentAnalysis(newAnalysisObject);
-                                pickerCombo.updateCellFactory();
+                                model.setCurrentAnalysisNOEVENT(newAnalysisObject);
                                 model.updateListAnalyses();
                                 model.isGlobalAnalysisTimeFrame(true);
-                                listAnalysesComboBox.getSelectionModel().select(model.getCurrentAnalysis());
+                                toolBarView.updateLayout();
                             }
                         } else {
 
@@ -188,14 +190,13 @@ public class SaveAnalysisDialog {
                             dialogOverwrite.getDialogPane().getButtonTypes().addAll(overwrite_ok, overwrite_cancel);
 
                             dialogOverwrite.showAndWait().ifPresent(overwrite_response -> {
-                                if (overwrite_response.getButtonData().getTypeCode() == ButtonType.OK.getButtonData().getTypeCode()) {
+                                if (overwrite_response.getButtonData().getTypeCode().equals(ButtonType.OK.getButtonData().getTypeCode())) {
                                     if (currentAnalysis.get() != null) {
                                         saveDataModel(currentAnalysis.get(), model.getSelectedData(), model.getCharts());
 
+                                        model.setCurrentAnalysisNOEVENT(currentAnalysis.get());
                                         model.updateListAnalyses();
-                                        model.setCurrentAnalysis(currentAnalysis.get());
-                                        pickerCombo.updateCellFactory();
-                                        listAnalysesComboBox.getSelectionModel().select(model.getCurrentAnalysis());
+                                        toolBarView.updateLayout();
                                     }
                                 } else {
 

--- a/JEVisControlCenter/src/main/java/org/jevis/jeconfig/plugin/charts/GraphPluginView.java
+++ b/JEVisControlCenter/src/main/java/org/jevis/jeconfig/plugin/charts/GraphPluginView.java
@@ -343,7 +343,7 @@ public class GraphPluginView implements Plugin {
         try {
             switch (cmdType) {
                 case Constants.Plugin.Command.SAVE:
-                    new SaveAnalysisDialog(ds, dataModel, toolBarView.getPickerCombo(), toolBarView.getListAnalysesComboBox(), toolBarView.getChanged());
+                    new SaveAnalysisDialog(ds, dataModel, toolBarView);
                     break;
                 case Constants.Plugin.Command.DELETE:
                     new DeleteAnalysisDialog(ds, dataModel, toolBarView.getListAnalysesComboBox());

--- a/JEVisControlCenter/src/main/java/org/jevis/jeconfig/plugin/charts/ToolBarView.java
+++ b/JEVisControlCenter/src/main/java/org/jevis/jeconfig/plugin/charts/ToolBarView.java
@@ -124,6 +124,10 @@ public class ToolBarView {
         this.ds = ds;
         this.objectRelations = new ObjectRelations(ds);
         this.graphPluginView = graphPluginView;
+
+        listAnalysesComboBox = new ComboBox<>(model.getObservableListAnalyses());
+        listAnalysesComboBox.setPrefWidth(300);
+        setCellFactoryForComboBox();
     }
 
     public ToolBar getToolbar(JEVisDataSource ds) {
@@ -138,8 +142,12 @@ public class ToolBarView {
     }
 
 
-    public void setupAnalysisComboBoxListener() {
+    public void addAnalysisComboBoxListener() {
         listAnalysesComboBox.valueProperty().addListener(analysisComboBoxChangeListener);
+    }
+
+    public void removeAnalysisComboBoxListener() {
+        listAnalysesComboBox.valueProperty().removeListener(analysisComboBoxChangeListener);
     }
 
     private void resetZoom() {
@@ -347,11 +355,7 @@ public class ToolBarView {
     public void updateLayout() {
         Platform.runLater(() -> {
 
-            listAnalysesComboBox = new ComboBox<>(model.getObservableListAnalyses());
-
-            listAnalysesComboBox.setPrefWidth(300);
-
-            setCellFactoryForComboBox();
+            removeAnalysisComboBoxListener();
 
             if (model.getCurrentAnalysis() != null) {
                 listAnalysesComboBox.getSelectionModel().select(model.getCurrentAnalysis());
@@ -393,7 +397,7 @@ public class ToolBarView {
                         sep4, calcRegression, showL1L2, showRawData, showSum, disableIcons, autoResize, runUpdateButton);
             }
 
-            setupAnalysisComboBoxListener();
+            addAnalysisComboBoxListener();
             pickerCombo.addListener();
             startToolbarIconListener();
 
@@ -460,7 +464,7 @@ public class ToolBarView {
         });
 
         save.setOnAction(action -> {
-            new SaveAnalysisDialog(ds, model, pickerCombo, listAnalysesComboBox, changed);
+            new SaveAnalysisDialog(ds, model, this);
         });
 
         loadNew.setOnAction(event -> {


### PR DESCRIPTION
…eichert wird, wird die richtige Analyse erst nach Refresh angezeigt fixes #1317

JECC - Diagramme - die Frage ob eine Analyse gespeichert werden soll kommt häufig auch wenn nichts geändert wurde fixes #1153